### PR TITLE
Add support for type 24 messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+ais_server
 [Tt]humbs.db
 *~
 .vscode/

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/tormol/AIS
+
+go 1.17
+
+require (
+	github.com/andmarios/aislib v0.0.0-20190131232958-3a9a58899c39
+	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/tormol/AIS v0.0.0-20181230234101-81f005650a97
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/andmarios/aislib v0.0.0-20190131232958-3a9a58899c39 h1:DKt7Sm4WePQkPuxLc18+SEXvHwp2aeQfYjzmzJaUSq8=
+github.com/andmarios/aislib v0.0.0-20190131232958-3a9a58899c39/go.mod h1:mRizI7/yf7fg+S2apPbMV4dNQM+2kPf12aR3XkWRBeU=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/tormol/AIS v0.0.0-20181230234101-81f005650a97 h1:hr78jXAlVNuAsNXSwoNzAPN4GsZhqPOMaeRnj2hyUms=
+github.com/tormol/AIS v0.0.0-20181230234101-81f005650a97/go.mod h1:I9B8EmDj5idSzalzAK5VwKMGFUDuDeM07TkyocfL82U=

--- a/server/archive.go
+++ b/server/archive.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"math"
 	"sync"
 	"time"
 
@@ -60,7 +61,7 @@ func (a *Archive) Save(msg chan *nmeais.Message) {
 				continue
 			}
 			err = a.updatePos(ps)
-			a.db.UpdateDynamic(ps.MMSI, storage.ShipPos{time.Now(), geo.Point{ps.Lat, ps.Lon}, storage.Accuracy(ps.Accuracy), storage.ShipNavStatus(15), ps.Heading, ps.Course, ps.Speed, 0})
+			a.db.UpdateDynamic(ps.MMSI, storage.ShipPos{time.Now(), geo.Point{ps.Lat, ps.Lon}, storage.Accuracy(ps.Accuracy), storage.ShipNavStatus(15), ps.Heading, ps.Course, ps.Speed, float32(math.NaN())})
 		case 24: // static data report
 			sdr, e := ais.DecodeStaticDataReport(m.ArmoredPayload())
 			if e != nil && sdr.MMSI <= 0 {

--- a/storage/shipDB.go
+++ b/storage/shipDB.go
@@ -151,7 +151,7 @@ var UnknownPos = ShipPos{
 	BowHeading:  uint16(math.NaN()),
 	Course:      float32(math.NaN()),
 	Speed:       float32(math.NaN()),
-	RateOfTurn:  float32(math.NaN()),
+	RateOfTurn:  0,
 }
 
 // ShipInfo stores information gathered from AIS message 5 and 24.

--- a/storage/shipDB.go
+++ b/storage/shipDB.go
@@ -151,7 +151,7 @@ var UnknownPos = ShipPos{
 	BowHeading:  uint16(math.NaN()),
 	Course:      float32(math.NaN()),
 	Speed:       float32(math.NaN()),
-	RateOfTurn:  0,
+	RateOfTurn:  float32(math.NaN()),
 }
 
 // ShipInfo stores information gathered from AIS message 5 and 24.


### PR DESCRIPTION
Added support for type 24 messages to catch static information from ships that don't emit type 5 messages.

I also migrated this to a go module, and changed the unknown value for `RateOfTurn` to `0` instead of `NaN`, otherwise when selecting a ship that only emits type 24, the following error was encountered, as type 24 doesn't contain `RateOfTurn`:
   ```
   json: error calling MarshalJSON for type geo.Point: json: unsupported value: NaN
   ```

I'm quite new to writing Go, so please do let me know if I'm off track with anything here.